### PR TITLE
Added required statement and metadata info to LD and HT manifests

### DIFF
--- a/img/derivatives/iiif/HardTimesTranscription/manifest.json
+++ b/img/derivatives/iiif/HardTimesTranscription/manifest.json
@@ -6,13 +6,26 @@ layout: none
   "@id": "{{ '/' | absolute_url }}img/derivatives/iiif/HardTimesTranscription/manifest.json",
   "@type": "sc:Manifest",
   "label": "Hard Times Transcription",
+  "viewingDirection": "left-to-right",
+  "rights": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Attribution"
+      ]
+    },
+    "value": {
+      "en": [
+        "© Digital Dickens Notes Project (DDNP) 2023<br>Editorial annotations by Adam Grener.<br>Editorial content, including annotations, is licensed under a Creative Commons CC BY-NC-SA 4.0 License.<br>The Hard Times Working Notes are part of the novel manuscript, which is held by the Victoria and Albert Museum's National Art Library. "
+      ]
+    }
+  },
   "metadata": [
     {
-      "label": "rights",
-      "value": "\u00a9 Digital Dickens Notes Project (DDNP) 2022<br>Editorial content, including annotations, is licensed under a Creative Commons CC BY-NC-SA 4.0 License.<br>"
+      "label": { "en": [ "MLA Citation: " ] },
+      "value": { "en": [ "Dickens, Charles. '<i>Hard Times</i> Working Notes,' transcribed and edited by Adam Grener and Isabel Parker. <i>Digital Dickens Notes Project.</i> Anna Gibson and Adam Grener, dirs. 2023. Web. http://dickensnotes.com/notes/hard-times/mirador/<br>Editorial annotations are written by Adam Grener and can be cited by annotation number (e.g. HT.III.L4)." ] }
     }
   ],
-  "viewingDirection": "left-to-right",
   "sequences": [
     {
       "@type": "sc:Sequence",

--- a/img/derivatives/iiif/davidcopperfieldtranscription/manifest.json
+++ b/img/derivatives/iiif/davidcopperfieldtranscription/manifest.json
@@ -7,12 +7,6 @@ layout: none
   "@type": "sc:Manifest",
   "label": "David Copperfield Transcription",
   "viewingDirection": "left-to-right",
-  "metadata": [
-    {
-      "label": { "en": [ "MLA Citation: " ] },
-      "value": { "en": [ "Dickens, Charles. '<i>David Copperfield</i> Working Notes,' transcribed and edited by Frankie Goodenough and Adam Grener. <i>Digital Dickens Notes Project.</i> Anna Gibson and Adam Grener, dirs. 2022. Web. https://dickensnotes.com/notes/david-copperfield/mirador/<br><br>Editorial annotations are written by Frankie Goodenough and can be cited by annotation number (e.g. DC.IV.R2)." ] }
-    }
-  ],
   "rights": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
   "requiredStatement": {
     "label": {
@@ -22,10 +16,16 @@ layout: none
     },
     "value": {
       "en": [
-        "© Digital Dickens Notes Project (DDNP) 2022<br>Editorial content, including annotations, is licensed under a Creative Commons CC BY-NC-SA 4.0 License.<br>The David Copperfield Working Notes are part of the novel manuscript, which is held by the Victoria and Albert Museum's National Art Library."
+        "© Digital Dickens Notes Project (DDNP) 2022<br>Editorial annotations by Frankie Goodenough.<br>Editorial content, including annotations, is licensed under a Creative Commons CC BY-NC-SA 4.0 License.<br>The David Copperfield Working Notes are part of the novel manuscript, which is held by the Victoria and Albert Museum's National Art Library."
       ]
     }
   },
+  "metadata": [
+    {
+      "label": { "en": [ "MLA Citation: " ] },
+      "value": { "en": [ "Dickens, Charles. '<i>David Copperfield</i> Working Notes,' transcribed and edited by Frankie Goodenough and Adam Grener. <i>Digital Dickens Notes Project.</i> Anna Gibson and Adam Grener, dirs. 2022. Web. https://dickensnotes.com/notes/david-copperfield/mirador/<br><br>Editorial annotations are written by Frankie Goodenough and can be cited by annotation number (e.g. DC.IV.R2)." ] }
+    }
+  ],
   "sequences": [
     {
       "@type": "sc:Sequence",

--- a/img/derivatives/iiif/littledorrittranscription/manifest.json
+++ b/img/derivatives/iiif/littledorrittranscription/manifest.json
@@ -6,13 +6,26 @@ layout: none
   "@id": "{{ '/' | absolute_url }}img/derivatives/iiif/littledorrittranscription/manifest.json",
   "@type": "sc:Manifest",
   "label": "Little Dorrit Transcription",
+  "viewingDirection": "left-to-right",
+  "rights": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Attribution"
+      ]
+    },
+    "value": {
+      "en": [
+        "© Digital Dickens Notes Project (DDNP) 2023<br>Editorial annotations by Anna Gibson.<br>Editorial content, including annotations, is licensed under a Creative Commons CC BY-NC-SA 4.0 License.<br>The Little Dorrit Working Notes are part of the novel manuscript, which is held by the Victoria and Albert Museum's National Art Library. "
+      ]
+    }
+  },
   "metadata": [
     {
-      "label": "rights",
-      "value": "https&#58;//creativecommons.org/licenses/by-nc-sa/4.0/"
+      "label": { "en": [ "MLA Citation: " ] },
+      "value": { "en": [ "Dickens, Charles. '<i>Bleak House</i> Working Notes,' transcribed and edited by Anna Gibson and Frankie Goodenough. <i>Digital Dickens Notes Project.</i> Anna Gibson and Adam Grener, dirs. 2023. Web. http://dickensnotes.com/notes/bleak-house/mirador/<br>Editorial annotations are written by Adam Grener and can be cited by annotation number (e.g. LD.IV.R2)." ] }
     }
   ],
-  "viewingDirection": "left-to-right",
   "sequences": [
     {
       "@type": "sc:Sequence",


### PR DESCRIPTION
Copied info for 'rights,' 'required statement,' and 'metadata' from Bleak House manifest into Hard Times and Little Dorrit manifests, then updated info 